### PR TITLE
Downloader can now be used to download files from the commoncrawl s3

### DIFF
--- a/src/cc-downloader.py
+++ b/src/cc-downloader.py
@@ -1,9 +1,12 @@
 import boto3
+import sys
 
-filename = ""
+# Run this script by following this example
+# python src/cc-downloader.py crawl-data/CC-MAIN-2020-50/segments/1606141753148.92/warc/CC-MAIN-20201206002041-20201206032041-00718.warc.gz
+# Note that there is no bucket name; only prefixes
+# File can be found in the tmp/ directory
 
-
+filename = sys.argv[1]
 s3 = boto3.client("s3")
 s3_resource = boto3.resource('s3')
-bucket_name = "commoncrawl"
-s3.get_object(Bucket=bucket_name, Key="filename")
+s3.download_file("commoncrawl", filename, './tmp/{0}'.format(os.path.split(filename)[1]))


### PR DESCRIPTION
It's a really stupid script, but it's maybe easier than doing aws s3 cp on my own. 

In the distributed implementation, there shouldn't be any downloading going on. I figured I'd just have a poorly designed tool just in case.